### PR TITLE
Add multi-res support to dimension resolvers

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,7 +19,7 @@
     "key-spacing"           : 0,
     "max-len"               : [0, 120, 2],
     "max-lines-per-function": ["warn", {"max": 30, "skipBlankLines": true, "skipComments": true}],
-    "no-unused-vars"        : [1, { "vars": "all", "args": "after-used", "ignoreRestSiblings": false }],
+    "no-unused-vars"        : [1, { "vars": "all", "args": "after-used", "ignoreRestSiblings": false, "argsIgnorePattern": "^_" }],
     "no-var"                : 1,
     "object-curly-spacing"  : [2, "always"],
     "prefer-const" : [1, {

--- a/README.md
+++ b/README.md
@@ -149,6 +149,21 @@ function handler(event) {
 }
 ```
 
+The `x-preflight-dimensions` header can take several shapes:
+
+* `{ width, height }` (or `[{ width, height }]`) - a straightforward, single-resolution image
+* `[{ width, height }, { width, height }, ...]` - a multi-resolution image with pages of the specified sizes
+* `{ width, height, pages }` - a multi-resolution image with the specified number of `pages`, each half the size of the one before
+* `{ width, height, limit }` - a multi-resolution image in which the smallest width and height are both less than the specified `limit`
+
+For example, the following dimension values would all describe the same pyramidal image:
+
+* `[{ width: 2048, height: 1536 }, { width: 1024, height: 768 }, { width: 512, height: 384 }]`
+* `{ width: 2048, height: 1536, pages: 3 }`
+* `{ width: 2048, height: 1536, limit: 480 }`
+
+The `limit` calculator will keep going until both dimensions are _less than_ the limit, not _less than or equal to_. So a `limit: 512` on the third example above would generate a fourth page at `{ width: 256, height: 192 }`.
+
 *Note:* The SAM deploy template adds a `preflight=true` environment variable to the main IIIF Lambda if a preflight function is provided. The function will _only_ look for the preflight headers if this environment variable is `true`. This prevents requests from including those headers directly if no preflight function is present. If you do use a preflight function, make sure it strips out any `x-preflight-location` and `x-preflight-dimensions` headers that it doesn't set itself.
 
 ## Notes

--- a/dependencies/package-lock.json
+++ b/dependencies/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "serverless-iiif-dependencies",
-  "version": "4.2.5",
+  "version": "4.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-iiif-dependencies",
-      "version": "4.2.5",
+      "version": "4.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "aws-sdk": "^2.368",
-        "iiif-processor": "^3.2.0"
+        "iiif-processor": "^3.2.2"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -319,9 +319,9 @@
       "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "node_modules/iiif-processor": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/iiif-processor/-/iiif-processor-3.2.1.tgz",
-      "integrity": "sha512-E6SfUpoC9/s6lNOwE5PkliWiODWGwFc7MaOwfjz/LCP5QenRzuxYTK+uDDRX3ygDUhqQz0nt8kIh4MN3UYkN+A==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/iiif-processor/-/iiif-processor-3.2.2.tgz",
+      "integrity": "sha512-cNc/52cnXLQ4LhFQHXFdHs6JNct+tQ8pjCHj4hras2cM4YPNwtsIN+YaA5M6Ugw5vx1IHH/Xlzt+I/sQU2B2qw==",
       "dependencies": {
         "debug": "^4.3.4",
         "mime-types": "2.x",
@@ -1038,9 +1038,9 @@
       "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "iiif-processor": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/iiif-processor/-/iiif-processor-3.2.1.tgz",
-      "integrity": "sha512-E6SfUpoC9/s6lNOwE5PkliWiODWGwFc7MaOwfjz/LCP5QenRzuxYTK+uDDRX3ygDUhqQz0nt8kIh4MN3UYkN+A==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/iiif-processor/-/iiif-processor-3.2.2.tgz",
+      "integrity": "sha512-cNc/52cnXLQ4LhFQHXFdHs6JNct+tQ8pjCHj4hras2cM4YPNwtsIN+YaA5M6Ugw5vx1IHH/Xlzt+I/sQU2B2qw==",
       "requires": {
         "debug": "^4.3.4",
         "mime-types": "2.x",

--- a/dependencies/package.json
+++ b/dependencies/package.json
@@ -1,11 +1,11 @@
 {
   "name": "serverless-iiif-dependencies",
-  "version": "4.2.5",
+  "version": "4.3.0",
   "description": "Dependencies for serverless IIIF",
   "author": "Michael B. Klein",
   "license": "Apache-2.0",
   "dependencies": {
     "aws-sdk": "^2.368",
-    "iiif-processor": "^3.2.0"
+    "iiif-processor": "^3.2.2"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-iiif",
-  "version": "4.2.5",
+  "version": "4.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-iiif",
-      "version": "4.2.5",
+      "version": "4.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "dotenv": "^16.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-iiif",
-  "version": "4.2.5",
+  "version": "4.3.0",
   "description": "Lambda wrapper for iiif-processor",
   "author": "Michael B. Klein",
   "license": "Apache-2.0",
@@ -34,6 +34,8 @@
     ]
   },
   "scripts": {
+    "lint": "eslint src/*.js",
+    "lint-fix": "eslint --fix src/*.js",
     "test": "node scripts/test.js --env=jsdom",
     "test-coverage": "node scripts/test.js --env=jsdom --coverage",
     "build": "./bin/build",

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "serverless-iiif",
-  "version": "4.2.5",
+  "version": "4.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-iiif",
-      "version": "4.2.5",
+      "version": "4.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "uri-js": "^4.4.1"
       },
       "devDependencies": {
         "aws-sdk": "^2.368.0",
-        "iiif-processor": "^3.2.0"
+        "iiif-processor": "^3.2.2"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -351,9 +351,9 @@
       "dev": true
     },
     "node_modules/iiif-processor": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/iiif-processor/-/iiif-processor-3.2.1.tgz",
-      "integrity": "sha512-E6SfUpoC9/s6lNOwE5PkliWiODWGwFc7MaOwfjz/LCP5QenRzuxYTK+uDDRX3ygDUhqQz0nt8kIh4MN3UYkN+A==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/iiif-processor/-/iiif-processor-3.2.2.tgz",
+      "integrity": "sha512-cNc/52cnXLQ4LhFQHXFdHs6JNct+tQ8pjCHj4hras2cM4YPNwtsIN+YaA5M6Ugw5vx1IHH/Xlzt+I/sQU2B2qw==",
       "dev": true,
       "dependencies": {
         "debug": "^4.3.4",
@@ -1163,9 +1163,9 @@
       "dev": true
     },
     "iiif-processor": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/iiif-processor/-/iiif-processor-3.2.1.tgz",
-      "integrity": "sha512-E6SfUpoC9/s6lNOwE5PkliWiODWGwFc7MaOwfjz/LCP5QenRzuxYTK+uDDRX3ygDUhqQz0nt8kIh4MN3UYkN+A==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/iiif-processor/-/iiif-processor-3.2.2.tgz",
+      "integrity": "sha512-cNc/52cnXLQ4LhFQHXFdHs6JNct+tQ8pjCHj4hras2cM4YPNwtsIN+YaA5M6Ugw5vx1IHH/Xlzt+I/sQU2B2qw==",
       "dev": true,
       "requires": {
         "debug": "^4.3.4",

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-iiif",
-  "version": "4.2.5",
+  "version": "4.3.0",
   "description": "Lambda wrapper for iiif-processor",
   "author": "Michael B. Klein",
   "license": "Apache-2.0",
@@ -9,6 +9,6 @@
   },
   "devDependencies": {
     "aws-sdk": "^2.368.0",
-    "iiif-processor": "^3.2.0"
+    "iiif-processor": "^3.2.2"
   }
 }

--- a/tests/__mocks/mockS3.js
+++ b/tests/__mocks/mockS3.js
@@ -25,14 +25,17 @@ const S3 = jest.fn().mockImplementation(() => {
       checkParams('S3.headObject', params);
       let md = {};
       if (params.Key === 'dimensions.tif') {
-        md = { width: '100', height: '200' };
-      };
+        md = { width: '2048', height: '1536' };
+      }
+      if (params.Key === 'paged-dimensions.tif') {
+        md = { width: '2048', height: '1536', pages: '5' };
+      }
       return {
         promise: () => {
           return {
             Metadata: md
           };
-        }
+        },
       };
     }
   };
@@ -40,10 +43,10 @@ const S3 = jest.fn().mockImplementation(() => {
 
 const upload = jest.fn((params, callback) => {
   checkParams('upload', params);
-  if (params.Key === "new_cache_key/default.jpg") {
+  if (params.Key === 'new_cache_key/default.jpg') {
     callback(null, {});
   } else {
-    callback("unknown cache key", null);
+    callback('unknown cache key', null);
   }
 });
 
@@ -54,7 +57,7 @@ const S3Cache = jest.fn().mockImplementation(() => {
       if (params.Key === 'cache_hit/default.jpg') {
         callback(null, {});
       } else {
-        callback("error", null);
+        callback('error', null);
       }
     },
     getSignedUrl: function (params) {


### PR DESCRIPTION
- Update `node-iiif` to `^3.2.2`
- Add pyramidal image support to the internal dimension resolver functions using similar patterns to the ones in `node-iiif`
- Add tests
- Update README
