### PR TITLE
Move CORS settings from template to code

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,20 @@ This lambda uses the Sharp layer from https://github.com/samvera/lambda-layer-sh
 
 ## Advanced Usage
 
+### Cross-Origin Request Sharing (CORS)
+
+For security reasons, web browsers have built in limits on what sort of requests can be made to a given domain from a page hosted under a different domain. Since this is a common use case for IIIF (resources embedded in pages whose domains differ from that of the server), IIIF interactions are particularly susceptible to these limits. The mechanism for determining which of these requests should be allowed or blocked is known as Cross-Origin Resource Sharing, or [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS). A full explanation of CORS is beyond the scope of this project, but the SAM deploy template contains five parameters relating to how the IIIF server handles CORS:
+
+* `CorsAllowCredentials` contains the value that will be returned in the `Access-Control-Allow-Credentials` response header.
+* `CorsAllowHeaders` contains the value that will be returned in the `Access-Control-Allow-Headers` response header.
+* `CorsAllowOrigin` contains the value that will be returned in the `Access-Control-Allow-Origin` response header. In addition, a special value, `REFLECT_ORIGIN`, instructs the IIIF server to copy the value of the incoming request's `Origin` header into the `Access-Control-Allow-Origin` response header.
+* `CorsExposeHeaders` contains the value that will be returned in the `Access-Control-Expose-Headers` response header.
+* `CorsMaxAge` contains the value that will be returned in the `Access-Control-Max-Age` response header.
+
+The default values will work in most circumstances, but if you need the IIIF server to accept requests that include credentials or other potentially sensitive information (e.g., `Authorization` and/or `Cookie` headers), you'll need to set `CorsAllowOrigin` to `REFLECT_ORIGIN` and `CorsAllowCredentials` to `true`. Other settings allow further customization.
+
+### Request/Response Functions
+
 The SAM deploy template takes several optional parameters to enable the association of [CloudFront Functions](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-functions.html) or [Lambda@Edge Functions](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-at-the-edge.html) with the CloudFront distribution. These functions can perform authentication and authorization functions, change how the S3 file and/or image dimensions are resolved, or alter the response from the lambda or cache. These parameters are:
 
 * `OriginRequestARN`: ARN of the Lambda@Edge Function to use at the origin-request stage
@@ -120,11 +134,11 @@ The SAM deploy template takes several optional parameters to enable the associat
 
 These functions, if used, must be created, configured, and published before the serverless application is deployed.
 
-### Examples
+#### Examples
 
 These examples use CloudFront Functions. Lambda@Edge functions are slightly more complicated in terms of the event structure but the basic idea is the same.
 
-#### Simple Authorization
+##### Simple Authorization
 
 ```JavaScript
 function handler(event) {
@@ -138,7 +152,7 @@ function handler(event) {
 }
 ```
 
-#### Custom File Location / Image Dimensions
+##### Custom File Location / Image Dimensions
 
 ```JavaScript
 function handler(event) {

--- a/sam/cloudfront/template.yml
+++ b/sam/cloudfront/template.yml
@@ -28,6 +28,14 @@ Metadata:
           - CachePolicyID
           - CachePriceClass
       - Label:
+          default: "CORS Configuration"
+        Parameters:
+          - CorsAllowCredentials
+          - CorsAllowHeaders
+          - CorsAllowOrigin
+          - CorsExposeHeaders
+          - CorsMaxAge
+      - Label:
           default: "Hostname Configuration"
         Parameters:
           - CacheDomainName
@@ -62,6 +70,36 @@ Parameters:
     Type: String
     Description: ARN of the ACM SSL Certification to use for the API Gateway Endpoint or CloudFront Cache
     Default: ""
+  CorsAllowCredentials:
+    Type: String
+    Description: |
+      Value of the CORS `Access-Control-Allow-Credentials` response header.
+      Must be `true` to allow requests with `Authorization` and/or
+      `Cookie` headers.
+    AllowedValues:
+      - false
+      - true
+    Default: false
+  CorsAllowHeaders:
+    Type: String
+    Description: Value of the CORS `Access-Control-Allow-Headers` response header
+    Default: "*"
+  CorsAllowOrigin:
+    Type: String
+    Description: |
+      Value of the CORS `Access-Control-Allow-Origin` response header.
+      Use the special value `REFLECT_ORIGIN` to copy the value from the
+      `Origin` request header (required to emulate `*` for XHR requests
+      using `Authorization` and/or `Cookie` headers).
+    Default: "*"
+  CorsExposeHeaders:
+    Type: String
+    Description: Value of the CORS `Access-Control-Expose-Headers` response header
+    Default: cache-control,content-language,content-length,content-type,date,expires,last-modified,pragma
+  CorsMaxAge:
+    Type: Number
+    Description: Value of the CORS `Access-Control-MaxAge` response header
+    Default: 3600
   SourceBucket:
     Type: String
     Description: Name of bucket containing source images
@@ -311,6 +349,11 @@ Resources:
       #   SemanticVersion: 4.3.0
       Parameters:
         CacheBucket: !Ref CacheBucket
+        CorsAllowCredentials: !Ref CorsAllowCredentials
+        CorsAllowOrigin: !Ref CorsAllowOrigin
+        CorsAllowHeaders: !Ref CorsAllowHeaders
+        CorsExposeHeaders: !Ref CorsExposeHeaders
+        CorsMaxAge: !Ref CorsMaxAge
         ForceHost:
           Fn::If:
             - DistributionCustomDomain

--- a/sam/standalone/template.yml
+++ b/sam/standalone/template.yml
@@ -22,6 +22,14 @@ Metadata:
           - PixelDensity
           - ResolverTemplate
       - Label:
+          default: "CORS Configuration"
+        Parameters:
+          - CorsAllowCredentials
+          - CorsAllowHeaders
+          - CorsAllowOrigin
+          - CorsExposeHeaders
+          - CorsMaxAge
+      - Label:
           default: "Internal Use Only – Do Not Change"
         Parameters:
           - CacheBucket
@@ -32,6 +40,36 @@ Parameters:
     Type: String
     Description: Bucket to use for caching results larger than 6MB
     Default: ""
+  CorsAllowCredentials:
+    Type: String
+    Description: |
+      Value of the CORS `Access-Control-Allow-Credentials` response header.
+      Must be `true` to allow requests with `Authorization` and/or
+      `Cookie` headers.
+    AllowedValues:
+      - false
+      - true
+    Default: false
+  CorsAllowHeaders:
+    Type: String
+    Description: Value of the CORS `Access-Control-Allow-Headers` response header
+    Default: "*"
+  CorsAllowOrigin:
+    Type: String
+    Description: |
+      Value of the CORS `Access-Control-Allow-Origin` response header.
+      Use the special value `REFLECT_ORIGIN` to copy the value from the
+      `Origin` request header (required to emulate `*` for XHR requests
+      using `Authorization` and/or `Cookie` headers).
+    Default: "*"
+  CorsExposeHeaders:
+    Type: String
+    Description: Value of the CORS `Access-Control-Expose-Headers` response header
+    Default: cache-control,content-language,content-length,content-type,date,expires,last-modified,pragma
+  CorsMaxAge:
+    Type: Number
+    Description: Value of the CORS `Access-Control-MaxAge` response header
+    Default: 3600
   ForceHost:
     Type: String
     Description: Forced hostname to use in responses
@@ -100,19 +138,6 @@ Resources:
         Ref: IiifLambdaMemory
       FunctionUrlConfig:
         AuthType: NONE
-        Cors:
-          AllowCredentials: false
-          AllowHeaders:
-            - "*"
-          AllowMethods:
-            - GET
-          AllowOrigins:
-            - "*"
-          ExposeHeaders:
-            - content-length
-            - content-type
-            - date
-          MaxAge: 3600
       Timeout:
         Ref: IiifLambdaTimeout
       CodeUri: ../../src
@@ -169,6 +194,11 @@ Resources:
               - UseCacheBucket
               - !Ref CacheBucket
               - !Ref AWS::NoValue
+          corsAllowCredentials: !Ref CorsAllowCredentials
+          corsAllowOrigin: !Ref CorsAllowOrigin
+          corsAllowHeaders: !Ref CorsAllowHeaders
+          corsExposeHeaders: !Ref CorsExposeHeaders
+          corsMaxAge: !Ref CorsMaxAge
           density:
             Fn::If:
               - UsePixelDensity

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,3 +1,35 @@
+const SafelistedResponseHeaders = 'cache-control,content-language,content-length,content-type,date,expires,last-modified,pragma';
+const CorsDefaults = {
+  AllowCredentials: 'false',
+  AllowOrigin: '*',
+  AllowHeaders: '*',
+  ExposeHeaders: SafelistedResponseHeaders,
+  MaxAge: '3600'
+};
+
+const corsSetting = (name) => {
+  return process.env[`cors${name}`] || CorsDefaults[name];
+};
+
+const allowOriginValue = (corsAllowOrigin, event) => {
+  if (corsAllowOrigin === 'REFLECT_ORIGIN') {
+    return event.headers.origin || '*';
+  }
+  return corsAllowOrigin;
+};
+
+const addCorsHeaders = (event, response) => {
+  response.headers = {
+    ...response.headers,
+    'Access-Control-Allow-Credentials': corsSetting('AllowCredentials'),
+    'Access-Control-Allow-Origin': allowOriginValue(corsSetting('AllowOrigin'), event),
+    'Access-Control-Allow-Headers': corsSetting('AllowHeaders'),
+    'Access-Control-Expose-Headers': corsSetting('ExposeHeaders'),
+    'Access-Control-Max-Age': corsSetting('MaxAge')
+  };
+  return response;
+};
+
 const eventPath = (event) => {
   return event.requestContext?.http?.path.replace(/\/*$/, '');
 };
@@ -33,11 +65,12 @@ const parseDensity = (value) => {
 };
 
 module.exports = {
-  eventPath: eventPath,
-  fileMissing: fileMissing,
-  getUri: getUri,
-  isBase64: isBase64,
-  isTooLarge: isTooLarge,
-  getRegion: getRegion,
-  parseDensity: parseDensity
+  addCorsHeaders,
+  eventPath,
+  fileMissing,
+  getUri,
+  isBase64,
+  isTooLarge,
+  getRegion,
+  parseDensity
 };

--- a/src/index.js
+++ b/src/index.js
@@ -6,22 +6,24 @@ const resolvers = require('./resolvers');
 const { errorHandler } = require('./error');
 
 const handleRequestFunc = async (event, context) => {
-  const { eventPath, fileMissing, getRegion } = helpers;
+  const { addCorsHeaders, eventPath, fileMissing, getRegion } = helpers;
 
   AWS.config.region = getRegion(context);
   context.callbackWaitsForEmptyEventLoop = false;
 
+  let response;
   if (event.requestContext?.http?.method === 'OPTIONS') {
     // OPTIONS REQUEST
-    return { statusCode: 204, body: null };
+    response = { statusCode: 204, body: null };
   } else if (fileMissing(event)) {
     // INFO.JSON REQUEST
     const location = eventPath(event) + '/info.json';
-    return { statusCode: 302, headers: { Location: location }, body: 'Redirecting to info.json' };
+    response = { statusCode: 302, headers: { Location: location }, body: 'Redirecting to info.json' };
   } else {
     // IMAGE REQUEST
-    return await handleResourceRequestFunc(event, context);
+    response = await handleResourceRequestFunc(event, context);
   }
+  return addCorsHeaders(event, response);
 };
 
 const handleResourceRequestFunc = async (event, context) => {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -32,7 +32,7 @@ describe('index.handler', () => {
 
     const expected = { statusCode: 204, body: null };
     const result = await handler(event, context);
-    expect(result).toEqual(expected);
+    expect(result).toMatchObject(expected);
   });
 
   describe("INFO.JSON request", () => {
@@ -100,7 +100,7 @@ describe('index.handler', () => {
   
       const expected = { statusCode: 302, headers: { Location: '/iiif/2/image_id/info.json' }, body: 'Redirecting to info.json' };
       const result = await handler(event, context);
-      expect(result).toEqual(expected);
+      expect(result).toMatchObject(expected);
     });  
   });
 
@@ -134,7 +134,7 @@ describe('index.handler', () => {
         body:  Buffer.from(body).toString('base64')
       };
       const result = await handler(event, context);
-      expect(result).toEqual(expected);
+      expect(result).toMatchObject(expected);
     });
 
     it('works with nonbase64 image.', async () => {
@@ -157,7 +157,7 @@ describe('index.handler', () => {
         body: body
       };
       const result = await handler(event, context);
-      expect(result).toEqual(expected);
+      expect(result).toMatchObject(expected);
     });
 
     it('returns 404 to force failover when cached file exists', async () => {
@@ -178,7 +178,7 @@ describe('index.handler', () => {
         body: ''
       };
       const result = await handler(event, context);
-      expect(result).toEqual(expected);
+      expect(result).toMatchObject(expected);
     });
 
     it('caches file and returns 404 to force failover when result is too large to return directly', async () => {
@@ -203,7 +203,7 @@ describe('index.handler', () => {
       };
       const result = await handler(event, context);
       expect(cache.makeCache).toHaveBeenCalled();
-      expect(result).toEqual(expected);
+      expect(result).toMatchObject(expected);
     });
 
     it('handles errors that arise during processing', async () => {
@@ -224,7 +224,7 @@ describe('index.handler', () => {
         statusCode: 500,
       };
       result = await handler(event, context);
-      expect(result).toEqual(expected);
+      expect(result).toMatchObject(expected);
     });
   });
 });


### PR DESCRIPTION
Because so many IIIF consumers (e.g., Clover, OpenSeadragon) have the option of using XHR with `credentials: true`, we need more fine-grained control over the CORS response headers (specifically `Access-Control-Allow-Credentials` and `Access-Control-Allow-Origin`. This PR moves the responsibility for those headers from the SAM template / Lambda Function configuration to the code itself. See the [`README` changes](https://github.com/samvera/serverless-iiif/pull/107/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R112-R122) for details.

Resolves #104 