### PR TITLE
Update basePath for GitHub pages.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,6 +40,8 @@ jobs:
         run: npm install
       - name: Build with Next.js
         run: npx --no-install next build
+        env:
+          NEXTJS_BASE_PATH: "/serverless-iiif"
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
         with:

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -4,10 +4,11 @@ const withNextra = require('nextra')({
 });
 
 module.exports = withNextra({
-  output: 'export',
+  basePath: process.env.NEXTJS_BASE_PATH || '',
   images: {
     unoptimized: true
-  }
+  },
+  output: 'export'
 });
 
 // If you have other Next.js configurations, you can pass them as the parameter:


### PR DESCRIPTION
This should help address the `basePath` issue causeing the Next.js assets to 404.

![image](https://github.com/samvera/serverless-iiif/assets/7376450/3e12a464-4096-4c4a-95b2-4a4dd97c4cbf)




