### PR TITLE
Add deprecated language to descriptions of CloudFront and Standalone applications

### DIFF
--- a/sam/cloudfront/template.yml
+++ b/sam/cloudfront/template.yml
@@ -2,7 +2,7 @@ Transform: "AWS::Serverless-2016-10-31"
 Metadata:
   AWS::ServerlessRepo::Application:
     Name: serverless-iiif-cloudfront
-    Description: IIIF Image API 2.1/3.0 server in an AWS Serverless Application (w/CloudFront Caching)
+    Description: (Deprecated) IIIF Image API 2.1/3.0 server in an AWS Serverless Application (w/CloudFront Caching)
     Author: Samvera
     SpdxLicenseId: Apache-2.0
     LicenseUrl: ../../LICENSE.txt

--- a/sam/standalone/template.yml
+++ b/sam/standalone/template.yml
@@ -2,7 +2,7 @@ Transform: "AWS::Serverless-2016-10-31"
 Metadata:
   AWS::ServerlessRepo::Application:
     Name: serverless-iiif-standalone
-    Description: Passthrough template to install serverless-iiif
+    Description: (Deprecated) Passthrough template to install serverless-iiif
     Author: Samvera
     SpdxLicenseId: Apache-2.0
     LicenseUrl: ../../LICENSE.txt


### PR DESCRIPTION
For clarity, add "deprecated" to the descriptions of the standalone and Cloudfront applications in the Serverless Application Repository

<img width="1326" alt="Screenshot 2024-05-29 at 11 06 56 AM" src="https://github.com/samvera/serverless-iiif/assets/6372022/6952acf7-fdf0-48f6-a4a6-0969439a5aa9">
