### PR TITLE
Stop calculating reduction at the page pixel limit instead of going one further

### DIFF
--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -43,7 +43,7 @@ const reduceToLimit = ({ width, height, limit }) => {
   const result = [{ width, height }];
   let page = 1;
   let currentPage = result[result.length - 1];
-  while (currentPage.width >= limit || currentPage.height >= limit) {
+  while (currentPage.width > limit || currentPage.height > limit) {
     const nextPage = calculatePage(result[0], page++);
     result.push(nextPage);
     currentPage = result[result.length - 1];

--- a/tests/resolvers.test.js
+++ b/tests/resolvers.test.js
@@ -150,7 +150,6 @@ describe('resolvers', () => { // eslint-disable-line max-lines-per-function
           { width: 1024, height: 768 },
           { width: 512, height: 384 },
           { width: 256, height: 192 },
-          { width: 128, height: 96 },
         ];
         const result = await dimensionResolver({id: 'dimensions'});
         expect(result).toEqual(expected);


### PR DESCRIPTION
Fixes #154 