### PR TITLE
Fix state drift bug

### DIFF
--- a/extras/terraform/README.md
+++ b/extras/terraform/README.md
@@ -46,16 +46,16 @@ module "serverless_iiif" {
 | Name                      | Description | Type | Default | Required |
 |---------------------------|-------------|------|---------|:--------:|
 | `cors_allow_credentials`  | Value of the CORS `Access-Control-Allow-Credentials` response header. Must be `true` to allow requests with `Authorization` and/or `Cookie` headers. | `bool` | `false` | no |
-| `cors_allow_headers`      | Value of the CORS `Access-Control-Allow-Headers` response header | `string` | `"*"` | no |
+| `cors_allow_headers`      | Value of the CORS `Access-Control-Allow-Headers` response header | `string` | `null` (upstream: `"*"`) | no |
 | `cors_allow_origin`       | Value of the CORS `Access-Control-Allow-Origin` response header. Use the special value `REFLECT_ORIGIN` to copy the value from the `Origin` request header (required to emulate `*` for XHR requests using `Authorization` and/or `Cookie` headers). | `string` | `"*"` | no |
-| `cors_expose_headers`     | Value of the CORS `Access-Control-Expose-Headers` response header | `string` | `"cache-control,content-language,content-length,content-type,date,expires,last-modified,pragma"` | no |
-| `cors_max_age`            | Value of the CORS `Access-Control-MaxAge` response header | `number` | `3600` | no |
+| `cors_expose_headers`     | Value of the CORS `Access-Control-Expose-Headers` response header | `string` | `null` (upstream: `"cache-control,content-language,content-length,content-type,date,expires,last-modified,pragma"`) | no |
+| `cors_max_age`            | Value of the CORS `Access-Control-MaxAge` response header | `number` | `null` (upstream: `3600`) | no |
 | `force_host`              | Forced hostname to use in responses | `string` | `""` | no |
-| `iiif_lambda_memory`      | The memory provisioned for the lambda. | `number` | `3008` | no |
-| `iiif_lambda_timeout`     | The timeout for the lambda | `number` | `10` | no |
-| `pixel_density`           | Hardcoded DPI/Pixel Density/Resolution to encode in output images | `number` | `0` | no |
+| `iiif_lambda_memory`      | The memory provisioned for the lambda. | `number` | `null` (upstream: `3008`) | no |
+| `iiif_lambda_timeout`     | The timeout for the lambda | `number` | `null` (upstream: `10`) | no |
+| `pixel_density`           | Hardcoded DPI/Pixel Density/Resolution to encode in output images | `number` | `null` (upstream: `0`) | no |
 | `preflight`               | Indicates whether the function should expect preflight headers | `bool`   | `false` | no |
-| `resolver_template`       | A printf-style format string that determines the location of source image within the bucket given the image ID | `string` | `"%s.tif"` | no |
+| `resolver_template`       | A printf-style format string that determines the location of source image within the bucket given the image ID | `string` | `null` (upstream: `"%s.tif"`) | no |
 | `sharp_layer`             | ARN of a custom AWS Lambda Layer containing the sharp and libvips dependencies. Use the special value `JP2` to use the managed JPEG2000-compatible layer, or `INTERNAL` to use the built-in dependencies (without JPEG2000 support). | `string` | `"JP2"` | no |
 | `source_bucket`           | Name of the S3 bucket containing source images | `string` | `""` | yes |
 | `stack_name`              | The stack name for the deployed serverless-iiif application | `string` | `""` | yes |

--- a/extras/terraform/main.tf
+++ b/extras/terraform/main.tf
@@ -9,27 +9,30 @@ terraform {
 }
 
 locals {
-  serverless_iiif_app_id        = "arn:aws:serverlessrepo:us-east-1:625046682746:applications/serverless-iiif"
-  serverless_iiif_app_version   = "8.0.0"
+  serverless_iiif_app_id      = "arn:aws:serverlessrepo:us-east-1:625046682746:applications/serverless-iiif"
+  serverless_iiif_app_version = "8.0.0"
+
+  _all_parameters = {
+    CorsAllowCredentials = tostring(var.cors_allow_credentials)
+    CorsAllowHeaders     = var.cors_allow_headers
+    CorsAllowOrigin      = var.cors_allow_origin
+    CorsExposeHeaders    = var.cors_expose_headers
+    CorsMaxAge           = var.cors_max_age != null ? tostring(var.cors_max_age) : null
+    ForceHost            = var.force_host
+    IiifLambdaMemory     = var.iiif_lambda_memory != null ? tostring(var.iiif_lambda_memory) : null
+    IiifLambdaTimeout    = var.iiif_lambda_timeout != null ? tostring(var.iiif_lambda_timeout) : null
+    PixelDensity         = var.pixel_density != null ? tostring(var.pixel_density) : null
+    Preflight            = var.preflight
+    ResolverTemplate     = var.resolver_template
+    SourceBucket         = var.source_bucket
+  }
+  parameters = { for k, v in local._all_parameters : k => v if v != null }
 }
 
 resource "aws_serverlessapplicationrepository_cloudformation_stack" "serverless_iiif" {
-  name                      = var.stack_name
-  application_id            = local.serverless_iiif_app_id
-  semantic_version          = local.serverless_iiif_app_version
-  capabilities              = ["CAPABILITY_IAM"]
-  parameters = {
-    CorsAllowCredentials    = var.cors_allow_credentials
-    CorsAllowHeaders        = var.cors_allow_headers
-    CorsAllowOrigin         = var.cors_allow_origin
-    CorsExposeHeaders       = var.cors_expose_headers
-    CorsMaxAge              = var.cors_max_age
-    ForceHost               = var.force_host
-    IiifLambdaMemory        = var.iiif_lambda_memory
-    IiifLambdaTimeout       = var.iiif_lambda_timeout
-    PixelDensity            = var.pixel_density
-    Preflight               = var.preflight
-    ResolverTemplate        = var.resolver_template
-    SourceBucket            = var.source_bucket
-  }
+  name             = var.stack_name
+  application_id   = local.serverless_iiif_app_id
+  semantic_version = local.serverless_iiif_app_version
+  capabilities     = ["CAPABILITY_IAM"]
+  parameters       = local.parameters
 }

--- a/extras/terraform/variables.tf
+++ b/extras/terraform/variables.tf
@@ -16,7 +16,7 @@ variable "cors_allow_credentials" {
 variable "cors_allow_headers" {
     type          = string
     description   = "Value of the CORS `Access-Control-Allow-Headers` response header"
-    default       = "*"
+    default       = null # upstream default: "*"
 }
 
 variable "cors_allow_origin" {
@@ -33,13 +33,13 @@ variable "cors_allow_origin" {
 variable "cors_expose_headers" {
     type          = string
     description   = "Value of the CORS `Access-Control-Expose-Headers` response header"
-    default       = "cache-control,content-language,content-length,content-type,date,expires,last-modified,pragma"
+    default       = null # upstream default: "cache-control,content-language,content-length,content-type,date,expires,last-modified,pragma"
 }
 
 variable "cors_max_age" {
     type          = number
     description   = "Value of the CORS `Access-Control-MaxAge` response header"
-    default       = 3600
+    default       = null # upstream default: 3600
 }
 
 variable "force_host" {
@@ -51,10 +51,10 @@ variable "force_host" {
 variable "iiif_lambda_memory" {
     type          = number
     description   = "The memory provisioned for the lambda"
-    default       = 3008
+    default       = null # upstream default: 3008
 
     validation {
-      condition       = var.iiif_lambda_memory >= 128 && var.iiif_lambda_memory <= 10240
+      condition       = var.iiif_lambda_memory == null || (var.iiif_lambda_memory >= 128 && var.iiif_lambda_memory <= 10240)
       error_message   = "iiif_lambda_memory must be between 128 and 10240"
     }
 }
@@ -62,13 +62,13 @@ variable "iiif_lambda_memory" {
 variable "iiif_lambda_timeout" {
     type          = number
     description   = "The timeout for the lambda"
-    default       = 10
+    default       = null # upstream default: 10
 }
 
 variable "pixel_density" {
     type          = number
     description   = "Hardcoded DPI/Pixel Density/Resolution to encode in output images"
-    default       = 0
+    default       = null # upstream default: 0
 }
 
 variable "preflight" {
@@ -80,7 +80,7 @@ variable "preflight" {
 variable "resolver_template" {
     type          = string
     description   = "A printf-style format string that determines the location of source image within the bucket given the image ID"
-    default       = "%s.tif"
+    default       = null # upstream default: "%s.tif"
 }
 
 variable "sharp_layer" {


### PR DESCRIPTION
Setting the defaults to match the upstream defaults causes the state to get stuck - we try to set the values, but the provider doesn't see a difference, so says nothing needs to change, so they're permanently out of sync.

The parameters block in `main.tf` always passes all 12 parameters to CloudFormation, including those whose values match the SAR application's own defaults. CloudFormation's DescribeStacks API only echoes back parameters that were explicitly set to a non-default value — parameters that match defaults are silently omitted from the API response.

This creates an unresolvable drift cycle for any parameter the user leaves at its default:

1. Terraform refreshes state → AWS returns only the non-default parameters → the default-value ones become null in state
2. Terraform compares config (has values) vs state (null) → plans to "add" them
3. Apply creates a CloudFormation changeset → CloudFormation evaluates it and says "No updates are to be performed" → changeset state is FAILED → Terraform errors